### PR TITLE
Add RawQuery interface for adding additional query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Query an indicator:
 from_ts = datetime.datetime(2022, 1, 1)
 to_ts = datetime.datetime(2022, 2, 1)
 group_by = ["country"]
-filter_clause = FilterClause(field="country", operator="in", values="US,UK"])
+filter_clause = FilterClause(field="country", operator="in", values="US,UK")
 query_filter = Filter(clauses=[filter_clause], operator="and")
 
-results = query(indicator["id"], from_ts, to_ts, group_by, query_filter=query_filter)
+results = query(indicator.id, from_ts, to_ts, group_by, query_filter=query_filter)
 
 # Convert results to a DataFrame
 results_df = results.to_df()

--- a/README.md
+++ b/README.md
@@ -69,3 +69,30 @@ results_df = results.to_df()
 # Save results to a CSV file
 results.to_csv("results.csv")
 ```
+
+Use the `RawQuery` interface to add additional query arguments
+_Note: Query arguments attached via the RawQuery interface are subject to changes in their backend interpretation. Use with caution_
+
+```python
+import lariat_client
+import datetime
+
+lariat_client.configure(api_key="some_key", application_key="some_other_key")
+indicator = lariat_client.get_indicator(id=1234)
+from_ts = datetime.datetime(2023, 5, 1)
+to_ts = datetime.datetime(2023, 5, 10)
+
+filter_clause = lariat_client.FilterClause(field="country", operator="in", values="USA")
+query_filter = lariat_client.Filter(clauses=[filter_clause], operator="and")
+
+raw_query = lariat_client.RawQuery(
+        indicator_id=indicator.id,
+        from_ts=from_ts,
+        to_ts=to_ts,
+        aggregate="distinct",
+        query_filter=query_filter
+)
+
+raw_query.add_query_argument("x_axis", "custom_x_axis")
+records = raw_query.send()
+```

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -75,6 +75,7 @@ Query an indicator:
    results.to_csv("results.csv")
 
 Use the RawQuery interface to add additional query arguments:
+*Note: Query arguments attached via the RawQuery interface are subject to changes in their backend interpretation. Use with caution*
 
 .. code:: python
     import lariat_client

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -73,3 +73,28 @@ Query an indicator:
 
    # Save results to a CSV file
    results.to_csv("results.csv")
+
+Use the RawQuery interface to add additional query arguments:
+
+.. code:: python
+    import lariat_client
+    import datetime
+
+    lariat_client.configure(api_key="some_key", application_key="some_other_key")
+    indicator = lariat_client.get_indicator(id=1234)
+    from_ts = datetime.datetime(2023, 5, 1)
+    to_ts = datetime.datetime(2023, 5, 10)
+
+    filter_clause = lariat_client.FilterClause(field="country", operator="in", values="USA")
+    query_filter = lariat_client.Filter(clauses=[filter_clause], operator="and")
+
+    raw_query = lariat_client.RawQuery(
+            indicator_id=indicator.id,
+            from_ts=from_ts,
+            to_ts=to_ts,
+            aggregate="distinct",
+            query_filter=query_filter
+    )
+
+    raw_query.add_query_argument("x_axis", "custom_x_axis")
+    records = raw_query.send()

--- a/lariat_client/__init__.py
+++ b/lariat_client/__init__.py
@@ -18,4 +18,5 @@ from .lariat_client import (
     get_indicator,
     s,
     query,
+    RawQuery,
 )

--- a/lariat_client/lariat_client.py
+++ b/lariat_client/lariat_client.py
@@ -330,21 +330,23 @@ class MetricRecordList:
                 vals = record.to_dict()
                 writer.writerow([vals[field] for field in output_array])
 
+
 class RawQuery:
     """A class representing a RawQuery to the Lariat metrics store.
 
     A RawQuery may be sent to the API via `raw_query.send()` to retrive a `MetricRecordList`
     """
-    def __init__(self,
-            indicator_id: int,
-            from_ts: datetime.datetime,
-            to_ts: datetime.datetime = None,
-            group_by: List[str] = None,
-            aggregate: str = None,
-            query_filter: Filter = None,
-            extra_args: Dict = None,
-        ):
 
+    def __init__(
+        self,
+        indicator_id: int,
+        from_ts: datetime.datetime,
+        to_ts: datetime.datetime = None,
+        group_by: List[str] = None,
+        aggregate: str = None,
+        query_filter: Filter = None,
+        extra_args: Dict = None,
+    ):
         self.indicator_id = indicator_id
         self.from_ts = from_ts
         self.to_ts = to_ts
@@ -354,7 +356,7 @@ class RawQuery:
         self.metric_query_extra_args = extra_args or {}
 
     def add_query_argument(self, key: str, value: str):
-        self.metric_query_extra_args.update({ key: value })
+        self.metric_query_extra_args.update({key: value})
 
     def to_json(self) -> Dict:
         indicator_id = self.indicator_id
@@ -376,7 +378,11 @@ class RawQuery:
         if query_filter:
             data_filter["operator"] = query_filter.operator
             data_filter["filters"] = [
-                {"field": clause.field, "operator": clause.operator, "value": clause.values}
+                {
+                    "field": clause.field,
+                    "operator": clause.operator,
+                    "value": clause.values,
+                }
                 for clause in query_filter.clauses
             ]
         data = {
@@ -387,7 +393,7 @@ class RawQuery:
                     "to_ts": int(to_ts.timestamp() * 1000),
                 },
                 "query": data_filter,
-            }
+            },
         }
 
         if metric_query_extra_args:
@@ -415,8 +421,6 @@ class RawQuery:
             logging.error(f"Timeout Error: {errt}")
         except requests.exceptions.RequestException as err:
             logging.error(f"Something went wrong: {err}")
-
-
 
 
 def get_raw_datasets(dataset_ids: List[int]) -> List[RawDataset]:
@@ -625,6 +629,7 @@ def get_indicator(id: int) -> Indicator:
     except requests.exceptions.RequestException as err:
         logging.error(f"Something went wrong: {err}")
         sys.exit(1)
+
 
 def query(
     indicator_id: int,

--- a/tests/test_lariat_client.py
+++ b/tests/test_lariat_client.py
@@ -229,37 +229,3 @@ def test_query(monkeypatch):
         assert result.records[1].evaluation_time == 1633017600
         assert result.records[1].value == 45.0
         assert result.records[1].dimensions == {"country": "US", "state": "CA"}
-
-def test_raw_query(monkeypatch):
-    with requests_mock.Mocker() as mocker:
-        mock_query_metrics(mocker)
-        indicator_id = 1
-        from_ts = datetime(2021, 9, 30)
-        to_ts = datetime(2021, 10, 1)
-        group_by = ["country", "state"]
-        aggregate = "sum"
-        query_filter = Filter(
-            clauses=[FilterClause(field="country", operator="eq", values="US")],
-            operator="AND",
-        )
-        output_format = "json"
-
-        result = query(
-            indicator_id,
-            from_ts,
-            to_ts,
-            group_by,
-            aggregate,
-            query_filter,
-            output_format,
-        )
-
-        assert isinstance(result, MetricRecordList)
-        assert len(result.records) == 2
-        assert result.records[0].evaluation_time == 1633014000
-        assert result.records[0].value == 42.0
-        assert result.records[0].dimensions == {"country": "US", "state": "CA"}
-        assert result.records[1].evaluation_time == 1633017600
-        assert result.records[1].value == 45.0
-        assert result.records[1].dimensions == {"country": "US", "state": "CA"}
-

--- a/tests/test_lariat_client.py
+++ b/tests/test_lariat_client.py
@@ -229,3 +229,37 @@ def test_query(monkeypatch):
         assert result.records[1].evaluation_time == 1633017600
         assert result.records[1].value == 45.0
         assert result.records[1].dimensions == {"country": "US", "state": "CA"}
+
+def test_raw_query(monkeypatch):
+    with requests_mock.Mocker() as mocker:
+        mock_query_metrics(mocker)
+        indicator_id = 1
+        from_ts = datetime(2021, 9, 30)
+        to_ts = datetime(2021, 10, 1)
+        group_by = ["country", "state"]
+        aggregate = "sum"
+        query_filter = Filter(
+            clauses=[FilterClause(field="country", operator="eq", values="US")],
+            operator="AND",
+        )
+        output_format = "json"
+
+        result = query(
+            indicator_id,
+            from_ts,
+            to_ts,
+            group_by,
+            aggregate,
+            query_filter,
+            output_format,
+        )
+
+        assert isinstance(result, MetricRecordList)
+        assert len(result.records) == 2
+        assert result.records[0].evaluation_time == 1633014000
+        assert result.records[0].value == 42.0
+        assert result.records[0].dimensions == {"country": "US", "state": "CA"}
+        assert result.records[1].evaluation_time == 1633017600
+        assert result.records[1].value == 45.0
+        assert result.records[1].dimensions == {"country": "US", "state": "CA"}
+


### PR DESCRIPTION
This PR exposes the ability to manipulate a section of the `query-metrics` request JSON directly. 

- A `RawQuery` object can be constructed using the same arguments as the `query` function.
- Additional query arguments can be added using the `add_query_argument("key", "value")`, which mutates the `RawQuery` object in place
- The object can subsequently be submitted to the API using `send()` to retrieve a `MetricsRecordsList`

_Note: Query arguments attached via the RawQuery interface are subject to changes in their backend interpretation. Use with caution_

